### PR TITLE
Send email Tag to Postmark API

### DIFF
--- a/Transport/PostmarkApiTransport.php
+++ b/Transport/PostmarkApiTransport.php
@@ -74,9 +74,10 @@ class PostmarkApiTransport extends AbstractApiTransport
             'TextBody' => $email->getTextBody(),
             'HtmlBody' => $email->getHtmlBody(),
             'Attachments' => $this->getAttachments($email),
+            'Tag' => $email->getHeaders()->getHeaderBody('Tag'),
         ];
 
-        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender', 'reply-to'];
+        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender', 'reply-to', 'tag'];
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
                 continue;


### PR DESCRIPTION
Postmark has some helpful functionality to tag emails, to make is easier to sort or filter in their UI.
<img width="943" alt="Screenshot 2019-11-30 at 17 17 50" src="https://user-images.githubusercontent.com/263021/69903094-92131380-1395-11ea-915c-9f0cce2ce3b9.png">

At the moment, tags can't be added when using the API transport. If adding a header "Tag: email-tag" to current email, the JSON payload is generated with that tag in "Headers" line and doesn't work.

This PR would allow the "Tag" header to be added at the root of JSON payload, ensuring valid payload for Postmark API https://postmarkapp.com/developer/api/email-api

Cheers