### PR TITLE
Allow setting the message stream from the mail message

### DIFF
--- a/Transport/PostmarkApiTransport.php
+++ b/Transport/PostmarkApiTransport.php
@@ -112,6 +112,12 @@ class PostmarkApiTransport extends AbstractApiTransport
 
                 continue;
             }
+            
+            if($header instanceof UnstructuredHeader && in_array($header->getName(), ['MessageStream', 'X-PM-MessageStream']) ) {
+                $payload['MessageStream'] = $header->getValue();
+
+                continue;
+            }
 
             if ($header instanceof MessageStreamHeader) {
                 $payload['MessageStream'] = $header->getValue();


### PR DESCRIPTION
### Problem
I noticed that when setting the message stream via the headers of a Mailable in Laravel, this is not persisted when in the config the `mail.postmark.message_stream_id` is set, because `$payload['MessageStream]` is dominant over the header variables.

### A bit more background
So, in a Laravel mailable, the code below for setting the `X-PM-MessageStream` or `MessageStream` through the headers does not work:

```php
public function headers(): Headers
    {
        return new Headers(
            text: [
                'X-PM-MessageStream' => 'fitce-broadcasts',
                'MessageStream' => 'fitce-broadcasts',
            ],
        );
    }
```

I don't understand why, but in `PostmarkApiTransport`, the check on the message stream header is not triggered, as the header, set through the above code (in the Laravel Mailable), will always be of the type `UnstructuredHeader`
```php
if ($header instanceof MessageStreamHeader) {
                $payload['MessageStream'] = $header->getValue();

                continue;
            }
```

### Solution alternative
My first thought was to update the lines below to not set a message stream if the payload headers have a `MessageStream` or `X-PM-MessageStream`, because then the Postmark servers will use the Header variable to select the stream.
```php
if (null !== $this->messageStream && !isset($payload['MessageStream'])) {
            $payload['MessageStream'] = $this->messageStream;
        }
```
But this would result in a rather messy code for the check, 

### Proposed solution
Therefore I believe it is better to add an extra check on the available headers and set the `$payload['MessageStream']` when the headers contain a value for `X-PM-MessageStream` or `MessageStream`.

